### PR TITLE
Add config.cache.auto_detect = false

### DIFF
--- a/20150606_entornos_desarrollo/vagrant/ejercicios.md
+++ b/20150606_entornos_desarrollo/vagrant/ejercicios.md
@@ -87,6 +87,7 @@ Vagrant.configure(2) do |config|
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
+    config.cache.auto_detect = false
     config.cache.enable :apt
     config.cache.enable :apt_lists
   end
@@ -114,6 +115,7 @@ Vagrant.configure(2) do |config|
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
+    config.cache.auto_detect = false
     config.cache.enable :apt
     config.cache.enable :apt_lists
   end


### PR DESCRIPTION
To enable indivuals buckets, cache buckets automatic detection must be
disabled.

Info obtanied from http://fgrehm.viewdocs.io/vagrant-cachier/usage